### PR TITLE
Improve UI with playful design

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
 </head>
 <body>
     <main id="game-container">
-        <h1>Self-Testing Trivia</h1>
+        <h1>Self-Testing Trivia 🎮</h1>
         <div id="start-screen" class="screen">
             <p>Test your knowledge and learn about self-testing for STDs like HIV!</p>
-            <button id="start-btn">Start Game</button>
+            <button id="start-btn">Let's Play!</button>
         </div>
         <div id="question-screen" class="screen hidden">
             <p id="question"></p>

--- a/script.js
+++ b/script.js
@@ -88,7 +88,8 @@ function showQuestion() {
     const li = document.createElement('li');
     const button = document.createElement('button');
     button.textContent = answer.text;
-    button.addEventListener('click', () => selectAnswer(answer.correct));
+    button.dataset.correct = answer.correct;
+    button.addEventListener('click', () => selectAnswer(button));
     li.appendChild(button);
     answerList.appendChild(li);
   });
@@ -101,12 +102,18 @@ function clearAnswers() {
   }
 }
 
-function selectAnswer(correct) {
-  if (correct) {
+function selectAnswer(selectedBtn) {
+  if (selectedBtn.dataset.correct === 'true') {
     score++;
   }
   Array.from(answerList.children).forEach((li) => {
-    li.firstChild.disabled = true;
+    const btn = li.firstChild;
+    btn.disabled = true;
+    if (btn === selectedBtn) {
+      btn.classList.add(btn.dataset.correct === 'true' ? 'correct' : 'wrong');
+    } else if (btn.dataset.correct === 'true') {
+      btn.classList.add('correct');
+    }
   });
   nextBtn.classList.remove('hidden');
 }

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 body {
-    font-family: Arial, sans-serif;
-    background: #f4f4f4;
+    font-family: "Comic Sans MS", "Comic Neue", sans-serif;
+    background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
     color: #333;
     display: flex;
     justify-content: center;
@@ -10,11 +10,11 @@ body {
 }
 
 #game-container {
-    background: white;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-    width: 320px;
+    background: rgba(255, 255, 255, 0.9);
+    padding: 20px 30px;
+    border-radius: 12px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    width: 360px;
     text-align: center;
 }
 
@@ -24,9 +24,24 @@ body {
 
 button {
     margin-top: 15px;
-    padding: 10px 20px;
-    font-size: 16px;
+    padding: 12px 24px;
+    font-size: 18px;
     cursor: pointer;
+    border: none;
+    border-radius: 8px;
+    background: linear-gradient(135deg, #ff6f61, #f9a602);
+    color: #fff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    transition: transform 0.1s ease, filter 0.2s ease;
+}
+
+button:hover:not(:disabled) {
+    filter: brightness(1.1);
+    transform: translateY(-2px);
+}
+
+button:disabled {
+    filter: brightness(0.8);
 }
 
 ul {
@@ -36,4 +51,12 @@ ul {
 
 li {
     margin: 5px 0;
+}
+
+.correct {
+    background-color: #4CAF50 !important;
+}
+
+.wrong {
+    background-color: #F44336 !important;
 }


### PR DESCRIPTION
## Summary
- liven up the page with a gradient background and playful fonts
- style buttons with colorful gradient and hover effect
- highlight correct and wrong answers after each selection
- adjust question rendering for new styling
- make title and start button more playful

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: no rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684012f398f4833094d6938565b43304