### PR TITLE
Add animated scoring and feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
             <button id="start-btn">Let's Play!</button>
         </div>
         <div id="question-screen" class="screen hidden">
+            <div id="hud">
+                <span id="scoreboard">Score: 0</span>
+                <span id="feedback"></span>
+            </div>
             <p id="question"></p>
             <ul id="answer-list"></ul>
             <button id="next-btn" class="hidden">Next</button>

--- a/script.js
+++ b/script.js
@@ -51,6 +51,8 @@ const questionEl = document.getElementById('question');
 const answerList = document.getElementById('answer-list');
 const nextBtn = document.getElementById('next-btn');
 const scoreEl = document.getElementById('score');
+const scoreboardEl = document.getElementById('scoreboard');
+const feedbackEl = document.getElementById('feedback');
 
 document.getElementById('start-btn').addEventListener('click', startGame);
 nextBtn.addEventListener('click', () => {
@@ -64,7 +66,6 @@ nextBtn.addEventListener('click', () => {
 
 document.getElementById('restart-btn').addEventListener('click', () => {
   currentQuestion = 0;
-  score = 0;
   showStart();
 });
 
@@ -72,6 +73,9 @@ function showStart() {
   resultScreen.classList.add('hidden');
   questionScreen.classList.add('hidden');
   startScreen.classList.remove('hidden');
+  score = 0;
+  updateScoreboard();
+  feedbackEl.textContent = '';
 }
 
 function startGame() {
@@ -94,6 +98,7 @@ function showQuestion() {
     answerList.appendChild(li);
   });
   nextBtn.classList.add('hidden');
+  feedbackEl.textContent = '';
 }
 
 function clearAnswers() {
@@ -103,8 +108,14 @@ function clearAnswers() {
 }
 
 function selectAnswer(selectedBtn) {
-  if (selectedBtn.dataset.correct === 'true') {
+  const isCorrect = selectedBtn.dataset.correct === 'true';
+  if (isCorrect) {
     score++;
+    updateScoreboard();
+    showFeedback(true);
+    launchConfetti();
+  } else {
+    showFeedback(false);
   }
   Array.from(answerList.children).forEach((li) => {
     const btn = li.firstChild;
@@ -122,6 +133,29 @@ function showResults() {
   questionScreen.classList.add('hidden');
   scoreEl.textContent = `You scored ${score} out of ${questions.length}!`;
   resultScreen.classList.remove('hidden');
+}
+
+function updateScoreboard() {
+  scoreboardEl.textContent = `Score: ${score}`;
+  scoreboardEl.classList.remove('score-pop');
+  void scoreboardEl.offsetWidth;
+  scoreboardEl.classList.add('score-pop');
+}
+
+function showFeedback(isCorrect) {
+  feedbackEl.textContent = isCorrect ? 'Correct!' : 'Try again!';
+  feedbackEl.className = isCorrect ? 'correct-text feedback-pop' : 'wrong-text feedback-pop';
+}
+
+function launchConfetti() {
+  for (let i = 0; i < 15; i++) {
+    const confetti = document.createElement('div');
+    confetti.classList.add('confetti');
+    confetti.style.left = Math.random() * 100 + '%';
+    confetti.style.backgroundColor = `hsl(${Math.random() * 360}, 70%, 60%)`;
+    document.body.appendChild(confetti);
+    setTimeout(() => confetti.remove(), 1500);
+  }
 }
 
 showStart();

--- a/style.css
+++ b/style.css
@@ -60,3 +60,60 @@ li {
 .wrong {
     background-color: #F44336 !important;
 }
+
+#hud {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+#scoreboard {
+    font-weight: bold;
+}
+
+#feedback {
+    min-height: 24px;
+    font-weight: bold;
+}
+
+.correct-text {
+    color: #4CAF50;
+}
+
+.wrong-text {
+    color: #F44336;
+}
+
+.score-pop {
+    animation: pop 0.5s ease;
+}
+
+.feedback-pop {
+    animation: fade 0.3s ease;
+}
+
+@keyframes pop {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.3); }
+    100% { transform: scale(1); }
+}
+
+@keyframes fade {
+    0% { opacity: 0; transform: scale(0.8); }
+    100% { opacity: 1; transform: scale(1); }
+}
+
+.confetti {
+    position: fixed;
+    top: -10px;
+    width: 8px;
+    height: 8px;
+    opacity: 0.7;
+    pointer-events: none;
+    animation: fall 1.5s linear forwards;
+}
+
+@keyframes fall {
+    to { transform: translateY(100vh) rotate(720deg); }
+}


### PR DESCRIPTION
## Summary
- show in-game score with animated counter
- provide clear correct/incorrect feedback and confetti celebration

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e1cdaff08330b313e9302a5b30e4